### PR TITLE
Add instructions to install cbc solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
 the package using an interface. Specifically, while you are located in the repository folder, execute the following:
   - ```cd gpbp_app``` to enter the application folder
   - ```streamlit run main_page.py``` to run the app, which will automatically open a browser window
-3. This package can perform optimizations using a variety of solvers. You can use a solver of your choice. For example, you can install the [COIN-OR Branch-and-Cut solver](https://github.com/coin-or/Cbc#download) and specify the path of the solver's binary to the argument `solver_path` of `jg_opt.OpenOptimize` (for example, after installation, on a Mac you can find the path to the solver using `which cbc`).
 
 ## Deploying/running the web interface (Docker)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 the package using an interface. Specifically, while you are located in the repository folder, execute the following:
   - ```cd gpbp_app``` to enter the application folder
   - ```streamlit run main_page.py``` to run the app, which will automatically open a browser window
+3. This package can perform optimizations using a variety of solvers. You can use a solver of your choice. For example, you can install the [COIN-OR Branch-and-Cut solver](https://github.com/coin-or/Cbc#download) and specify the path of the solver's binary to the argument `solver_path` of `jg_opt.OpenOptimize` (for example, after installation, on a Mac you can find the path to the solver using `which cbc`).
 
 ## Deploying/running the web interface (Docker)
 

--- a/examples/gpbp_showcase.ipynb
+++ b/examples/gpbp_showcase.ipynb
@@ -135,7 +135,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Optimize"
+    "## Optimize\n",
+    "\n",
+    "PISA can perform optimizations using a variety of solvers. You can use a solver of your choice. For example, you can install the [COIN-OR Branch-and-Cut solver](https://github.com/coin-or/Cbc#download) and specify the path of the solver's binary below (on Linux/macOS you can find the path to the solver using `which cbc`)."
    ]
   },
   {


### PR DESCRIPTION
I think there's plenty of room for improvement (e.g. try to change the instructions to use docker, or find a way to get a default solver installed with python) and we should remove all hardcoded paths from the codebase, but for now this should be sufficient to run the `gpbp_showcase.ipynb` fully.